### PR TITLE
add purescript-tuples as dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-signal": "~2.2.1"
+    "purescript-signal": "~2.2.1",
+    "purescript-tuples": "~0.3.4"
   }
 }


### PR DESCRIPTION
I was getting an "Unknown Module" error when building.
I'm assuming at some point the Tuple lib was removed from Prelude or something and now we're required to add it as an explicit dependency. Builds work now for me, let me know if this is correct.